### PR TITLE
revert the changes so that my website is redirected to jianjin.xyz

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -5,7 +5,7 @@ reading_time: true
 words_per_minute: 200
 # Your site's domain goes here (eg: //mmistakes.github.io, http://mademistakes.com, etc)
 # When testing locally leave blank or use http://localhost:4000
-# url:              //jianjin.xyz
+url:              //jianjin.xyz
 
 # Owner/author information
 owner:


### PR DESCRIPTION
Revert "remove redirect to old customize url in config"

This reverts commit 594afd45fc27bdf247faea8f752cc5a46fa1a942.